### PR TITLE
生成コードに誤りが発生するgenerateのバグ修正

### DIFF
--- a/example/iwrapper_http_responsewriter.go
+++ b/example/iwrapper_http_responsewriter.go
@@ -29,35 +29,35 @@ func ResponseWriterWrapper(v http.ResponseWriter, wrapper func(http.ResponseWrit
 		return struct {
 			http.ResponseWriter
 			http.Hijacker
-			http.CloseNotifier
-			http.Flusher
-		}{wrapped, wrapped, wrapped, wrapped}
+		}{wrapped, wrapped}
 	case 0b10:
 		return struct {
 			http.ResponseWriter
-		}{wrapped}
+			http.CloseNotifier
+		}{wrapped, wrapped}
 	case 0b11:
 		return struct {
 			http.ResponseWriter
 			http.Hijacker
 			http.CloseNotifier
-			http.Flusher
-		}{wrapped, wrapped, wrapped, wrapped}
+		}{wrapped, wrapped, wrapped}
 	case 0b100:
 		return struct {
 			http.ResponseWriter
-		}{wrapped}
+			http.Flusher
+		}{wrapped, wrapped}
 	case 0b101:
 		return struct {
 			http.ResponseWriter
 			http.Hijacker
-			http.CloseNotifier
 			http.Flusher
-		}{wrapped, wrapped, wrapped, wrapped}
+		}{wrapped, wrapped, wrapped}
 	case 0b110:
 		return struct {
 			http.ResponseWriter
-		}{wrapped}
+			http.CloseNotifier
+			http.Flusher
+		}{wrapped, wrapped, wrapped}
 	case 0b111:
 		return struct {
 			http.ResponseWriter

--- a/internal/generate.go
+++ b/internal/generate.go
@@ -213,6 +213,7 @@ func getBody(valueIdent, wrapFuncIdent *ast.Ident, valueType ast.Expr, optionalI
 				})
 				elementsExprs = append(elementsExprs, wrappedValueIdent)
 			}
+			tmpI >>= 1
 		}
 
 		caseClauseStmts = append(caseClauseStmts, &ast.CaseClause{


### PR DESCRIPTION
1箇所shift演算が抜けており、動的な構造体構築に誤りが発生するバグがあったので修正した。